### PR TITLE
Mapping incomping ATLAS Photometry (JSON) to TarXiv JSON format (OSC Schema)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ This database is also aimed at facilitating micro-services provided by [Astro-Co
 
 ### Citing the data sources easily with BibTex
 [TBD]
-
+blabl
 


### PR DESCRIPTION
## Schema Choice

The [Open Supernova Catalogue schema](https://github.com/astrocatalogs/schema) is well thought out and can be used as is for TarXiv (and expanded if needed). No need to re-invent the wheel. 

The **photometry** is reported in the OSC Schema under the ``photometry`` key as a list of dictionaries.

## Added in this PR 

I have added the ``mapping_atlas_to_tarxiv`` function which takes in ATLAS JSON data and extracts the photometry into the list of dictionaries with the OSC schema keys. I have included an option to include non detections. 

I have updated the functions relating to fetching the ATLAS LC accordingly to call the ``mapping_atlas_to_tarxiv``. 

## Still needed

* We have to create the main part of the JSON data probably from TNS. (To be discussed) 
* How will updating the LCs work? do we grab everything again and _replace_ or do we append? The latter seems more finicky. 
* On testing **I can't test locally so hard to know if things will pass or fail when i push**
