### PR TITLE
Add alternative email alert parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "cherrypy",
     "python-logstash-async"
 ]
-requires-python = ">3.9"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 dev = [
@@ -49,3 +49,10 @@ find = {}
 
 #[tool.setuptools.package-data]
 #"tarxiv.data" = ["*.csv"]
+
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "imap",
+    "gmail",
+]

--- a/tarxiv/alerts.py
+++ b/tarxiv/alerts.py
@@ -13,6 +13,9 @@ import signal
 import base64
 import time
 import os
+import imaplib
+import email
+import re
 
 class Gmail(TarxivModule):
     """Module for interfacing with gmail and parsing TNS alerts."""
@@ -208,6 +211,206 @@ class Gmail(TarxivModule):
 
                 # Submit to queue for processing
                 self.q.put((message, alerts))
+
+    def _signal_handler(self, sig, frame):
+        status = {"status": "received exit signal", "signal": str(sig), "frame": str(frame)}
+        self.logger.info(status, extra=status)
+        self.stop_monitoring()
+        os._exit(1)
+
+
+
+class IMAP(TarxivModule):
+    """Module for interfacing with an IMAP email server and parsing TNS alerts."""
+
+    def __init__(self, script_name, reporting_mode=7, debug=False):
+        """Create module, authenticate with IMAP server and establish connection."""
+        super().__init__(
+            script_name=script_name,
+            module="imap",
+            reporting_mode=reporting_mode,
+            debug=debug
+        )
+
+        # Logging
+        self.logger.info({"status": "connecting to IMAP server"})
+
+        # IMAP connection
+        self.conn = None
+        try:
+            self.conn = imaplib.IMAP4_SSL(self.config["imap"]["server"])
+            self.conn.login(
+                self.config["imap"]["username"], self.config["imap"]["password"]
+            )
+            self.conn.select("inbox")
+            self.logger.info({"status": "connection success"})
+        except Exception as e:
+            self.logger.error({"status": "connection failed", "error": str(e)})
+            raise
+
+        # Create thread value
+        self.t = None
+        # Create internal queue
+        self.q = Queue()
+        # Create stop flag for monitoring
+        self.stop_event = threading.Event()
+        # Signals
+        signal.signal(signal.SIGINT, self._signal_handler)
+        signal.signal(signal.SIGTERM, self._signal_handler)
+
+    def poll(self, timeout=1):
+        """Once we have began monitoring notices, poll the queue for new messages and alerts
+
+        :param timeout, seconds; int
+        :return: poll result tuple containing the original message id and a list of tns object names; (message_id, alerts)
+                 if there is nothing in the queue then poll will return None after the timeout has expired.
+        """
+        try:
+            result = self.q.get(block=True, timeout=timeout)
+        except Empty:
+            result = None, None
+
+        return result
+
+    def parse_message(self, msg_bytes):
+        """Parse a raw email message for tns object names
+
+        :param msg_bytes: raw email message as bytes
+        :return: list of tns object names
+        """
+        alerts = []
+        msg = email.message_from_bytes(msg_bytes)
+
+        # Only process emails from TNS
+        if self.config["tns"]["email"] in msg.get("From", ""):
+            body = ""
+            if msg.is_multipart():
+                for part in msg.walk():
+                    content_type = part.get_content_type()
+                    if "text/html" in content_type:
+                        body = part.get_payload(decode=True).decode()
+                        break
+                    elif "text/plain" in content_type:
+                        payload = part.get_payload(decode=True)
+                        charset = part.get_content_charset() or 'utf-8'
+                        if payload:
+                            body = payload.decode(charset, errors='replace')
+                            break  # Prefer text/plain
+
+            else:
+                body = msg.get_payload(decode=True).decode()
+
+            if body:
+                soup = BeautifulSoup(body, features="html.parser")
+                # find all a tags with a href
+                alerts.extend([a.text for a in soup.find_all("a", href=True) if a.text])
+                # if no a tags, search for transient names in the text
+                if not alerts:
+                    alerts.extend(re.findall(r'\b(20\d{2}[a-z]{2,3})\b', body))
+
+        return alerts
+
+    def mark_read(self, message_id, verbose=False):
+        """Marks message as read in IMAP server, so it won't show up again in our monitoring stream
+
+        :param message_id: message uid (bytes)
+        :return: void
+        """
+        self.conn.uid("STORE", message_id, "+FLAGS.SILENT", r"(\Seen)")
+        status = {"action": "message_read", "id": message_id.decode()}
+        if verbose:
+            self.logger.info(status)
+        else:
+            self.logger.debug(status)
+
+    def mark_unread(self, message_id, verbose=False):
+        """Marks message as unread in IMAP server, so it will show up again in our monitoring stream
+
+        :param message_id: message uid (bytes)
+        :return: void
+        """
+        self.conn.uid("STORE", message_id, "-FLAGS.SILENT", r"(\Seen)")
+        status = {"action": "message_unread", "id": message_id.decode()}
+        if verbose:
+            self.logger.info(status)
+        else:
+            self.logger.debug(status)
+
+    def monitor_notices(self):
+        """Starts thread to monitor IMAP account for tns alerts:
+
+        :return: void
+        """
+        self.t = threading.Thread(target=self._monitoring_thread, daemon=True)
+        self.t.start()
+        self.logger.info({"status": "starting monitoring thread"})
+
+    def stop_monitoring(self):
+        """Kill monitoring thread.
+
+        :return: void
+        """
+        if self.t is not None:
+            self.stop_event.set()
+            self.t.join()
+        if self.conn:
+            self.conn.logout()
+        self.logger.info({"status": "stopping monitoring thread"})
+
+    def _monitoring_thread(self):
+        """Continuously monitor IMAP inbox for new messages.
+
+        Each new message is parsed of tns object alerts and results are submitted to local queue.
+        """
+        while not self.stop_event.is_set():
+            try:
+                self.conn.select("inbox")
+                # Search unread by UID
+                typ, data = self.conn.uid("SEARCH", None, "UNSEEN")
+                if typ != "OK":
+                    self.logger.error({"status": "error searching inbox"})
+                    time.sleep(self.config["imap"]["polling_interval"])
+                    continue
+
+                uids = data[0].split()
+                if not uids:
+                    time.sleep(self.config["imap"]["polling_interval"])
+                    continue
+
+                for uid in uids:
+                    # Fetch by UID without setting \Seen
+                    typ, msg_data = self.conn.uid("FETCH", uid, "(BODY.PEEK[])")
+                    if typ != "OK":
+                        self.logger.debug({"status": "error fetching message", "id": uid, "error": str(msg_data)})
+                        continue
+
+                    raw_email = msg_data[0][1]
+                    alerts = self.parse_message(raw_email)
+
+                    # Treat empty list as "no alerts"
+                    if not alerts:
+                        self.mark_read(uid)
+                        continue
+                    else:
+                        self.mark_unread(uid)
+
+                    self.logger.debug({"status": "received alerts", "objects": alerts})
+                    self.q.put((uid.decode(), alerts))
+
+                time.sleep(self.config["imap"]["polling_interval"])
+
+            except (imaplib.IMAP4.abort, imaplib.IMAP4.error) as e:
+                self.logger.warning({"status": "connection error, reconnecting", "error": str(e)})
+                try:
+                    self.conn = imaplib.IMAP4_SSL(self.config["imap"]["server"])
+                    self.conn.login(self.config["imap"]["username"], self.config["imap"]["password"])
+                except Exception as recon_e:
+                    self.logger.error({"status": "reconnection failed", "error": str(recon_e)})
+                    self.stop_event.set() # Stop if we can't reconnect
+            except Exception as e:
+                self.logger.error({"status": "unexpected error in monitoring thread", "error": str(e)})
+                time.sleep(self.config["imap"]["polling_interval"] * 2)
+
 
     def _signal_handler(self, sig, frame):
         status = {"status": "received exit signal", "signal": str(sig), "frame": str(frame)}

--- a/tarxiv/tests/test_alerts.py
+++ b/tarxiv/tests/test_alerts.py
@@ -1,0 +1,271 @@
+import base64
+import os
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+from tarxiv.alerts import Gmail, IMAP
+
+
+@pytest.fixture
+def mock_config_data():
+    """Provides a standard config dictionary."""
+    return {
+        "gmail": {
+            "token_name": "token.json",
+            "secrets_file": "secrets.json",
+            "scopes": ["https://www.googleapis.com/auth/gmail.readonly"],
+            "polling_interval": 1,
+        },
+        "imap": {
+            "server": "imap.test.com",
+            "username": "user",
+            "password": "password",
+            "polling_interval": 1,
+        },
+        "tns": {"email": "tns@example.com"},
+    }
+
+
+@pytest.fixture
+def mock_config(monkeypatch, tmp_path, mock_config_data):
+    """Mock TarxivModule to provide a standard config."""
+
+    def mock_init(self, module, *args, **kwargs):
+        self.config = mock_config_data
+        self.config_dir = str(tmp_path)
+        self.logger = MagicMock()
+
+    monkeypatch.setattr("tarxiv.utils.TarxivModule.__init__", mock_init)
+
+    # Create a dummy config.yml file
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(
+        """imap:\n  server: imap.test.com\n  username: user\n  password: password\n  polling_interval: 1\n"""
+    )
+
+    # Create a dummy secrets.json file
+    secrets_file = tmp_path / "secrets.json"
+    secrets_file.write_text(
+        """{
+        "installed": {
+            "client_id": "dummy-client-id",
+            "project_id": "dummy-project",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+            "client_secret": "dummy-client-secret",
+            "redirect_uris": ["urn:ietf:wg:oauth:2.0:oob", "http://localhost"]
+        }
+    }"""
+    )
+    return mock_config_data
+
+
+@pytest.mark.gmail
+def test_gmail_init_no_token(mock_config):
+    """Test Gmail initialization when no token exists."""
+    with (
+        patch("os.path.exists") as mock_exists,
+        patch(
+            "google.oauth2.credentials.Credentials.from_authorized_user_file"
+        ),
+        patch(
+            "google_auth_oauthlib.flow.InstalledAppFlow.from_client_secrets_file"
+        ) as mock_flow_from_secrets,
+        patch("tarxiv.alerts.build") as mock_build,
+        patch("builtins.open", mock_open()),
+    ):
+        # Mock file existence: secrets.json exists, token.json does not
+        def exists_side_effect(path):
+            if "secrets.json" in path:
+                return True
+            if "token.json" in path:
+                return False
+            return False
+
+        mock_exists.side_effect = exists_side_effect
+
+        # Mock the flow creation and OAuth flow
+        mock_flow_instance = MagicMock()
+        mock_flow_from_secrets.return_value = mock_flow_instance
+
+        # Mock credentials returned from OAuth flow
+        mock_creds_instance = MagicMock()
+        mock_creds_instance.valid = True
+        mock_creds_instance.to_json.return_value = '{"token": "new_oauth_token"}'
+        mock_flow_instance.run_local_server.return_value = mock_creds_instance
+
+        # Mock Gmail API service
+        mock_service = MagicMock()
+        mock_build.return_value = mock_service
+
+        # Create Gmail instance
+        gmail = Gmail(script_name="test", reporting_mode=7)
+
+        # Verify OAuth flow was called correctly
+        config_dir = gmail.config_dir
+        secrets_path = os.path.join(config_dir, "secrets.json")
+
+        # Verify OAuth flow was called
+        mock_exists.assert_called()
+        mock_flow_from_secrets.assert_called_with(
+            secrets_path, ["https://www.googleapis.com/auth/gmail.readonly"]
+        )
+        mock_flow_instance.run_local_server.assert_called_with(port=0)
+        mock_build.assert_called_with("gmail", "v1", credentials=mock_creds_instance)
+
+        assert gmail.service is not None
+
+
+@pytest.mark.gmail
+def test_gmail_init_with_existing_token(mock_config):
+    """Test Gmail initialization when token already exists and is valid."""
+    with (
+        patch("os.path.exists") as mock_exists,
+        patch("google.auth.transport.requests.Request") as mock_request,
+        patch(
+            "google.oauth2.credentials.Credentials.from_authorized_user_file"
+        ) as mock_from_authorized_user_file,
+        patch("tarxiv.alerts.build") as mock_build,
+        patch("builtins.open", mock_open()),
+    ):
+        # Mock file existence: both secrets.json and token.json exist
+        mock_exists.return_value = True
+
+        # Mock existing valid credentials
+        mock_creds_instance = MagicMock()
+        mock_creds_instance.valid = True
+        mock_creds_instance.to_json.return_value = '{"token": "existing_token"}'
+        mock_from_authorized_user_file.return_value = mock_creds_instance
+
+        # Mock Gmail API service
+        mock_service = MagicMock()
+        mock_build.return_value = mock_service
+
+        # Mock the Request for token refresh
+        mock_request_instance = MagicMock()
+        mock_request.return_value = mock_request_instance
+
+        # Create Gmail instance
+        gmail = Gmail(script_name="test", reporting_mode=7)
+
+        # Verify existing token was loaded and refreshed
+        config_dir = gmail.config_dir
+        token_path = os.path.join(config_dir, "token.json")
+
+        # Verify existing token was loaded and refreshed
+        mock_from_authorized_user_file.assert_called_with(
+            token_path, ["https://www.googleapis.com/auth/gmail.readonly"]
+        )
+        mock_creds_instance.refresh.assert_called()
+        mock_build.assert_called_with("gmail", "v1", credentials=mock_creds_instance)
+
+        assert gmail.service is not None
+
+
+@pytest.mark.gmail
+@patch("tarxiv.alerts.Gmail.__init__", return_value=None)
+def test_gmail_parse_message(mock_gmail_init, mock_config):
+    """Test parsing a valid TNS email message."""
+    gmail = Gmail(script_name="test", reporting_mode=7)
+    gmail.config = mock_config
+    gmail.logger = MagicMock()
+    html_content = (
+        '<html><body><a href="http://example.com/tns/2023xyz">2023xyz</a></body></html>'
+    )
+    encoded_content = base64.urlsafe_b64encode(html_content.encode("utf-8")).decode(
+        "utf-8"
+    )
+    msg = {
+        "payload": {
+            "headers": [{"name": "From", "value": "Some Name <tns@example.com>"}],
+            "body": {"data": encoded_content},
+        }
+    }
+    alerts = gmail.parse_message(msg)
+    assert alerts == ["2023xyz"]
+
+
+@pytest.mark.imap
+@patch("imaplib.IMAP4_SSL")
+def test_imap_init_success(mock_imap, mock_config):
+    """Test IMAPEmail initialization success."""
+    mock_conn = MagicMock()
+    mock_imap.return_value = mock_conn
+    imap_email = IMAP(script_name="test", reporting_mode=7)
+    mock_imap.assert_called_with("imap.test.com")
+    mock_conn.login.assert_called_with("user", "password")
+    mock_conn.select.assert_called_with("inbox")
+    assert imap_email.conn is not None
+
+
+@pytest.mark.imap
+@patch("imaplib.IMAP4_SSL")
+def test_imap_parse_message(mock_imap, mock_config):
+    """Test parsing a valid TNS email from IMAP."""
+    mock_conn = MagicMock()
+    mock_imap.return_value = mock_conn
+    imap_email = IMAP(script_name="test", reporting_mode=7)
+    imap_email.config = mock_config
+    html_content = (
+        '<html><body><a href="http://example.com/tns/2023abc">2023abc</a></body></html>'
+    )
+    msg = MIMEMultipart()
+    msg["From"] = "tns@example.com"
+    msg["To"] = "recipient@example.com"
+    msg["Subject"] = "TNS Alert"
+    msg.attach(MIMEText(html_content, "html"))
+
+    alerts = imap_email.parse_message(msg.as_bytes())
+    assert alerts == ["2023abc"]
+
+
+@pytest.mark.gmail
+@pytest.mark.imap
+@patch("tarxiv.alerts.Gmail.__init__", return_value=None)
+@patch("imaplib.IMAP4_SSL")
+def test_dummy_tns_email(mock_imap, _, mock_config):
+    """Test parsing a dummy TNS email with both Gmail and IMAP parsers."""
+    # Dummy email body (shortened to avoid overly long lines)
+    email_body = (
+        "The following new transient/s were reported:\n\n"
+        '<a href="https://www.wis-tns.org/object/2025sae">2025sae</a>\n\n'
+        "Best Regards,\n"
+        "The TNS team"
+    )
+    html_content_gmail = f"<html><body><p>{email_body}</p></body></html>"
+    encoded_content = base64.urlsafe_b64encode(
+        html_content_gmail.encode("utf-8")
+    ).decode("utf-8")
+
+    # Gmail test
+    gmail = Gmail(script_name="test", reporting_mode=7)
+    gmail.config = mock_config
+    gmail.logger = MagicMock()
+    msg = {
+        "payload": {
+            "headers": [{"name": "From", "value": "Some Name <tns@example.com>"}],
+            "body": {"data": encoded_content},
+        }
+    }
+    alerts = gmail.parse_message(msg)
+    assert alerts == ["2025sae"]
+
+    # IMAP test
+    mock_conn = MagicMock()
+    mock_imap.return_value = mock_conn
+    imap_email = IMAP(script_name="test", reporting_mode=7)
+    imap_email.config = mock_config
+    html_content_imap = f"<html><body><p>{email_body}</p></body></html>"
+    msg = MIMEMultipart()
+    msg["From"] = "tns@example.com"
+    msg["To"] = "recipient@example.com"
+    msg["Subject"] = "TNS Alert"
+    msg.attach(MIMEText(html_content_imap, "html"))
+
+    alerts = imap_email.parse_message(msg.as_bytes())
+    assert alerts == ["2025sae"]
+

--- a/tarxiv/utils.py
+++ b/tarxiv/utils.py
@@ -23,7 +23,10 @@ class TarxivModule:
         # Set module
         self.module = module
         # Read in config
-        self.config_dir = os.environ["TARXIV_CONFIG_DIR"]
+        self.config_dir = os.environ.get(
+            "TARXIV_CONFIG_DIR",
+            os.path.join(os.path.dirname(__file__), "../aux")
+        )
         self.config_file = os.path.join(self.config_dir, "config.yml")
         with open(self.config_file) as stream:
             self.config = yaml.safe_load(stream)


### PR DESCRIPTION
Adds an alternative alerts email parser that hooks into the standard python imap library, and uses the imap backend of gmail accounts to read from the same source as the gmail parser. Addresses #19 .

Requires a new section in the config file:
```
imap:
  server: "imap.gmail.com"
  username: "{{TarxivEmail}}"
  password: "{{TarxivAppPassword}}"
  polling_interval: 4
```

where the server can be replaced by a self hosted mailbox (with imap active obviously) if we so choose and the password field is actually an [App password](https://support.google.com/mail/answer/185833?hl=en-GB#). It might **not be great to store the app password in plain text in the config file** on the server long term so we could update this to use environment variables or something? Open to suggestions.

I've manually tested + written unit tests so am reasonably happy it works as intended, but further testing with a QA setup on docker compose is still on my to-do list. The only outstanding question from my end is why we're not marking emails as read once they've been parsed for alerts, @gonzodeveloper?
